### PR TITLE
Allow `SCHAN == 0`

### DIFF
--- a/raw_file_group.cpp
+++ b/raw_file_group.cpp
@@ -58,7 +58,7 @@ RawFileGroup::RawFileGroup(const vector<string>& filenames, int num_bands)
   timesteps_per_block = header.num_timesteps;
 
   schan = header.getInt("SCHAN", -1);
-  assert(schan > 0);
+  assert(schan >= 0);
   synctime = header.getUnsignedInt("SYNCTIME", -1);
   assert(synctime > 0);
   piperblk = header.getUnsignedInt("PIPERBLK", -1);


### PR DESCRIPTION
The first value of `SCHAN` is always 0 (for the first allocated processing instance). As things are now, processing is aborted when `SCHAN` is 0, for example:  

```seticore: ../raw_file_group.cpp:61: RawFileGroup::RawFileGroup(const std::vector<std::__cxx11::basic_string<char> >&, int): Assertion `schan > 0' failed.
srun: error: blpn0: task 0: Aborted```