### PR TITLE
* meson.build dependencies PIC, seticor lib and dep definitions

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "fmt"]
-	path = subprojects/fmt
-	url = https://github.com/fmtlib/fmt
 [submodule "capnproto"]
 	path = subprojects/capnproto
 	url = https://github.com/capnproto/capnproto.git

--- a/meson.build
+++ b/meson.build
@@ -88,12 +88,12 @@ tests = [
 # Dependency objects for super-project_version
 
 lib_seticore_dep = declare_dependency(
-    include_directories : include_directories('.'),
+    include_directories : [include_directories('.'), include_directories('raw')],
     dependencies: deps,
     link_with: library(
         'seticore',
         srcs,
-        include_directories : include_directories('.'),
+        include_directories : [include_directories('.'), include_directories('raw')],
         dependencies: deps,
         install: true
     ),

--- a/meson.build
+++ b/meson.build
@@ -16,12 +16,7 @@ else
     cuda_args = basic_cuda_args + newer_cuda_args
 endif
     
-cmake = import('cmake')
-
-fmt_opts = cmake.subproject_options()
-fmt_opts.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
-fmt_subproj = cmake.subproject('fmt', options: fmt_opts)
-fmt_dep = fmt_subproj.dependency('fmt')
+fmt_dep = subproject('fmt').get_variable('fmt_dep')
 
 boost_dep = dependency('boost', modules: [
     'filesystem',
@@ -33,6 +28,7 @@ hdf5_dep = dependency('hdf5', language: 'c')
 
 cuda_dep = dependency('cuda', version: '>=11', modules: ['cublas', 'cufft'])
 
+cmake = import('cmake')
 capnp_opt = cmake.subproject_options()
 capnp_opt.set_override_option('warning_level', '0')
 capnp_opt.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ basic_cuda_args = [ '--std=c++14' ]
 newer_cuda_args = [ '--display-error-number',
                     '--diag-suppress=1675' ]
 
-nvcc_release = '11.4' # run_command('./nvcc_release.sh', check: true).stdout().strip()
+nvcc_release = run_command('./nvcc_release.sh', check: true).stdout().strip()
 if nvcc_release <= '11.0'
     cuda_args = basic_cuda_args
 else

--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,7 @@ basic_cuda_args = [ '--std=c++14' ]
 newer_cuda_args = [ '--display-error-number',
                     '--diag-suppress=1675' ]
 
-nvcc_release = run_command('./nvcc_release.sh', check: true).stdout().strip()
+nvcc_release = '11.4' # run_command('./nvcc_release.sh', check: true).stdout().strip()
 if nvcc_release <= '11.0'
     cuda_args = basic_cuda_args
 else
@@ -18,7 +18,9 @@ endif
     
 cmake = import('cmake')
 
-fmt_subproj = cmake.subproject('fmt')
+fmt_opts = cmake.subproject_options()
+fmt_opts.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
+fmt_subproj = cmake.subproject('fmt', options: fmt_opts)
 fmt_dep = fmt_subproj.dependency('fmt')
 
 boost_dep = dependency('boost', modules: [
@@ -33,6 +35,7 @@ cuda_dep = dependency('cuda', version: '>=11', modules: ['cublas', 'cufft'])
 
 capnp_opt = cmake.subproject_options()
 capnp_opt.set_override_option('warning_level', '0')
+capnp_opt.add_cmake_defines({'CMAKE_POSITION_INDEPENDENT_CODE': true})
 capnp_subproj = cmake.subproject('capnproto', options: capnp_opt)
 kj_dep = capnp_subproj.dependency('kj')
 capnp_dep = capnp_subproj.dependency('capnp')
@@ -81,6 +84,20 @@ tests = [
     'multibeam_buffer_test.cpp',
     'taylor_test.cu',
 ]
+
+# Dependency objects for super-project_version
+
+lib_seticore_dep = declare_dependency(
+    include_directories : include_directories('.'),
+    dependencies: deps,
+    link_with: library(
+        'seticore',
+        srcs,
+        include_directories : include_directories('.'),
+        dependencies: deps,
+        install: true
+    ),
+)
 
 # The main binaries
 

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fmt-9.0.0
+source_url = https://github.com/fmtlib/fmt/archive/9.0.0.tar.gz
+source_filename = fmt-9.0.0.tar.gz
+source_hash = 9a1e0e9e843a356d65c7604e2c8bf9402b50fe294c355de0095ebd42fb9bd2c5
+patch_filename = fmt_9.0.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_9.0.0-1/get_patch
+patch_hash = 5f12924065e0fe7ccae40593d256a082955c273cb2880b3e3de05df9d8d10697
+wrapdb_version = 9.0.0-1
+
+[provide]
+fmt = fmt_dep


### PR DESCRIPTION
This allows seticore to easily be included as a meson subproject.