### PR TITLE
^ meson.build fmt static

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,3 @@
 [submodule "raw"]
 	path = raw
 	url = https://github.com/lacker/raw.git
-[submodule "subprojects/fmt"]
-	path = subprojects/fmt
-	url = https://github.com/fmtlib/fmt.git

--- a/meson.build
+++ b/meson.build
@@ -15,10 +15,13 @@ if nvcc_release <= '11.0'
 else
     cuda_args = basic_cuda_args + newer_cuda_args
 endif
-
-cmake = import('cmake')
-fmt_subproj = cmake.subproject('fmt')		
-fmt_dep = fmt_subproj.dependency('fmt')
+    
+fmt_dep = dependency(
+    'fmt',
+    default_options: [
+        'default_library=static'
+    ]
+)
 
 boost_dep = dependency('boost', modules: [
     'filesystem',

--- a/subprojects/fmt.wrap
+++ b/subprojects/fmt.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = fmt-9.1.0
+source_url = https://github.com/fmtlib/fmt/archive/9.1.0.tar.gz
+source_filename = fmt-9.1.0.tar.gz
+source_hash = 5dea48d1fcddc3ec571ce2058e13910a0d4a6bab4cc09a809d8b1dd1c88ae6f2
+patch_filename = fmt_9.1.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/fmt_9.1.0-1/get_patch
+patch_hash = 4557b9ba87b3eb63694ed9b21d1a2117d4a97ca56b91085b10288e9a5294adf8
+wrapdb_version = 9.1.0-1
+
+[provide]
+fmt = fmt_dep


### PR DESCRIPTION
#20 lagging fixes...

Allowed me to cp the binary to a separate directory and run it there (just usage output).