### PR TITLE
* python viewer accepts .stamp files too

### DIFF
--- a/python/viewer.py
+++ b/python/viewer.py
@@ -412,6 +412,8 @@ def find_stamp_files(directory):
             full = os.path.join(root, f)
             if full.endswith(".stamps"):
                 yield full
+            elif full.endswith(".stamp"):
+                yield full
                 
 def scan_dir(directory):
     """


### PR DESCRIPTION
I'm outputting `.stamp` files... are you dead set on these files being `.stamps`?