### PR TITLE
* HitFileWriter frequency public padding class variable

### DIFF
--- a/event_file_writer.cpp
+++ b/event_file_writer.cpp
@@ -16,7 +16,7 @@ using namespace std;
 
 EventFileWriter::EventFileWriter(const string& filename,
                  const vector<shared_ptr<FilterbankFileReader> >& metadatas)
-  : metadatas(metadatas), tmp_filename(filename + ".tmp"), final_filename(filename)
+  : metadatas(metadatas), tmp_filename(filename + ".tmp"), final_filename(filename), channel_padding(40)
 {
   fd = open(tmp_filename.c_str(), O_WRONLY | O_CREAT, 0664);
   if (fd < 0) {
@@ -52,6 +52,9 @@ void EventFileWriter::write(const vector<DedopplerHit*>& hits,
     low_index = min(low_index, hits[i]->lowIndex());
     high_index = max(high_index, hits[i]->highIndex());
   }
+  
+  low_index -= channel_padding;
+  high_index += channel_padding;
   
   int beam = hits[0]->beam;
   int coarse_channel = hits[0]->coarse_channel;

--- a/event_file_writer.h
+++ b/event_file_writer.h
@@ -18,6 +18,9 @@ class EventFileWriter {
   const string final_filename;
   
  public:
+  // The number of extra columns on each side of the filterbank-data to store
+  int channel_padding;
+
   EventFileWriter(const string& filename,
                   const vector<shared_ptr<FilterbankFileReader> >& metadatas);
   ~EventFileWriter();

--- a/hit_file_writer.cpp
+++ b/hit_file_writer.cpp
@@ -79,7 +79,7 @@ void buildFilterbank(const FilterbankMetadata& metadata, int beam, int coarse_ch
   // Find the interval [begin_index, end_index) that we actually want to copy over
   // Pad with extra columns but don't run off the edge
   long begin_index = max(low_index, 0L);
-  long end_index = min(high_index, metadata.coarse_channel_size) - 1;
+  long end_index = min(high_index, metadata.coarse_channel_size);
   long num_channels = end_index - begin_index;
   long coarse_offset = coarse_channel * metadata.coarse_channel_size;
   filterbank.setNumChannels(num_channels);

--- a/hit_file_writer.h
+++ b/hit_file_writer.h
@@ -20,9 +20,12 @@ class HitFileWriter: public HitRecorder {
 
   const string tmp_filename;
   const string final_filename;
+
   
  public:
   bool verbose;
+  // The number of extra columns on each side of the hit to store
+  int channel_padding;
   
   HitFileWriter(const string& filename, const FilterbankMetadata& metadata);
   ~HitFileWriter();


### PR DESCRIPTION
I'm in the midst of a debug mode that spoofs hits such that the exhaustive beamformed data is available across all of the filterbank data in the .hits file.

The static 'extra_columns' was messing me around. I'll be tuning it to zero in this debug mode.
